### PR TITLE
Add docker-compose rm

### DIFF
--- a/control-services/cli/jenkins.py
+++ b/control-services/cli/jenkins.py
@@ -17,6 +17,10 @@ class Jenkins():
         container = ['jenkins']
 
         self.docker.compose_stop(container)
+        
+        # Jenkins needs an rm because changes are
+        #   made via the Dockerfile, not an API
+        self.docker.compose_rm(container)
         self.docker.compose_up(container)
 
     def access(self):

--- a/control-services/cli/vDocker.py
+++ b/control-services/cli/vDocker.py
@@ -29,6 +29,15 @@ class VDocker():
 
         subprocess.check_output(cmd, universal_newlines=True)
 
+    def compose_rm(self, containers):
+        containers = self.__makeStrList(containers)
+
+        cmd = self.composePreface + [
+                'rm', '-sf',
+            ] + containers
+
+        subprocess.check_output(cmd, universal_newlines=True)
+
     def system_prune(self):
 
         cmd = self.dockerPreface + [


### PR DESCRIPTION
I added a `compose-rm` to `vDocker.py` that can be implemented by services that need image rebuilds for changes to appear after the restart. This was necessary for to implemented in the `jenkins.py` restart function to solve #146. 

Considerations should be made for when to use this. Previously the `docker system prune` was used with #57, where something similar to `compose-rm` was causing the container to regenerate it's encryption key. I think this is safe to add the `docker rm` function in `vDocker.py` and we can implement in services as necesarry. 