### PR TITLE
Iss145

### DIFF
--- a/control-services/cli/gitea.py
+++ b/control-services/cli/gitea.py
@@ -120,18 +120,6 @@ class Gitea():
         )
 
     def __copyLatestContentRepo(self, branch):
-        # Pull from remote to local, assuming local does not have uncommitted changes
-        # git --git-dir /home/control/$CONFIG_REPO_NAME/.git pull
-        
-        #out = check_output(
-        #    [
-        #        'git', '--git-dir',
-        #        self.cfg['host']['content_git_dir_path'], 'pull',
-        #        'origin', branch
-        #    ],
-        #    universal_newlines=True
-        #)
-
         # Check to see if an old repo exists in gitea
 
         out = ''
@@ -173,9 +161,6 @@ class Gitea():
                 'clone', '-b', branch, '--single-branch',
                 self.cfg['host']['content_dir_path'],
                 self.cfg['gitea']['content_repo_path']
-#                'sudo', 'cp', '-r', '-u',
-#                self.cfg['host']['content_dir_path'],
-#                self.cfg['gitea']['content_repo_path']
             ],
             universal_newlines=True
         )

--- a/control-services/cli/gitea.py
+++ b/control-services/cli/gitea.py
@@ -84,8 +84,8 @@ class Gitea():
         # Revokes token
         self.__revokeConfigurationToken()
 
-    def syncContentRepo(self):
-        self.__copyLatestContentRepo()
+    def syncContentRepo(self, branch):
+        self.__copyLatestContentRepo(branch)
         self.api.post(
             url=self.cfg['gitea']['api']['mirror_sync_url']
         )
@@ -119,16 +119,18 @@ class Gitea():
             ' --must-change-password=false'
         )
 
-    def __copyLatestContentRepo(self):
+    def __copyLatestContentRepo(self, branch):
         # Pull from remote to local, assuming local does not have uncommitted changes
         # git --git-dir /home/control/$CONFIG_REPO_NAME/.git pull
-        out = check_output(
-            [
-                'git', '--git-dir',
-                self.cfg['host']['content_git_dir_path'], 'pull'
-            ],
-            universal_newlines=True
-        )
+        
+        #out = check_output(
+        #    [
+        #        'git', '--git-dir',
+        #        self.cfg['host']['content_git_dir_path'], 'pull',
+        #        'origin', branch
+        #    ],
+        #    universal_newlines=True
+        #)
 
         # Check to see if an old repo exists in gitea
         p = Path(self.cfg['gitea']['content_repo_path'])
@@ -166,7 +168,7 @@ class Gitea():
             [
                 'sudo', 'git', '--git-dir',
                 self.cfg['host']['content_git_dir_path'],
-                'clone',
+                'clone', '-b', branch, '--single-branch',
                 self.cfg['host']['content_dir_path'],
                 self.cfg['gitea']['content_repo_path']
 #                'sudo', 'cp', '-r', '-u',
@@ -182,7 +184,7 @@ class Gitea():
             [
                 'sudo', 'git', '--git-dir',
                 self.cfg['gitea']['content_repo_git_dir_path'],
-                'branch', '-m', '-f', 'main', 'master'
+                'branch', '-m', '-f', branch, 'master'
             ],
             universal_newlines=True
         )

--- a/control-services/cli/gitea.py
+++ b/control-services/cli/gitea.py
@@ -219,7 +219,7 @@ class Gitea():
 
         if repoID == None:
             # Ensure the repository is available for migration in Gitea
-            self.__copyLatestContentRepo()
+            self.__copyLatestContentRepo('main')
             self.api.post(
                 url = self.cfg['gitea']['api']['repos_migrate'],
                 data = (

--- a/control-services/cli/parser.py
+++ b/control-services/cli/parser.py
@@ -92,7 +92,12 @@ class Parser():
             help =  'Syncs the upstream content repository'
                     ' with the Gitea content repository'
         )
-
+        self.__parser_sync.add_argument(
+            '-b', '--branch',
+            help = 'A github branch',
+            choices = container_choices + ['all'],
+            default = 'main'
+        )
         ### Config subparser
         self.__parser_sync = self.__subparsers.add_parser(
             'config',

--- a/control-services/cli/parser.py
+++ b/control-services/cli/parser.py
@@ -17,7 +17,7 @@ class Parser():
         # The path to the configuration file, used
         #   to setup the rest of the parser
 
-        homedir = "/home/" + getpass.getuser()
+        self.homedir = "/home/" + getpass.getuser()
 
         self.__parser.add_argument(
             '-c', '--configPath',

--- a/control-services/cli/parser.py
+++ b/control-services/cli/parser.py
@@ -2,6 +2,7 @@ import argparse
 import copy
 from collections import OrderedDict
 import os
+import subprocess
 
 class Parser():
     def __init__(self):
@@ -92,17 +93,20 @@ class Parser():
             help =  'Syncs the upstream content repository'
                     ' with the Gitea content repository'
         )
-        self.__parser_sync.add_argument(
-            '-b', '--branch',
-            help = 'A github branch',
-            choices = container_choices + ['all'],
-            default = 'main'
-        )
-        ### Config subparser
+                ### Config subparser
         self.__parser_sync = self.__subparsers.add_parser(
             'config',
             description =   'Prints the current configuration',
             help =  'Prints the current configuration'
+        )
+        self.__parser_sync.add_argument(
+            '-b', '--branch',
+            help = 'Specify a github branch in rous to sync to gitea',
+            os.chdir("/home/control/rous"),
+            branches = subprocess.run(["git","branch","-r"]),
+            print("test: %d" % branches.returncode),       
+            choices = branches.returncode,
+            default = 'main'
         )
 
         ### Stop subparser

--- a/control-services/cli/vater.py
+++ b/control-services/cli/vater.py
@@ -41,7 +41,6 @@ def task(config, args):
 def sync(config, args):
     g = Gitea(config)
     loginGitea(g)
-    print(args)
     g.syncContentRepo(args.branch)
 
 def config(config, args):

--- a/control-services/cli/vater.py
+++ b/control-services/cli/vater.py
@@ -41,7 +41,8 @@ def task(config, args):
 def sync(config, args):
     g = Gitea(config)
     loginGitea(g)
-    g.syncContentRepo()
+    print(args)
+    g.syncContentRepo(args.branch)
 
 def config(config, args):
     print(config)


### PR DESCRIPTION
Add `vater sync -b [branch]`. 

Tested with `vater sync -b iss82` and got:
<img width="832" alt="iss82PNG" src="https://user-images.githubusercontent.com/55300322/146618293-969bcd30-c613-4687-a778-03fc73f068a7.PNG">

And `vater sync`, which defaults to `branch = main`:
<img width="801" alt="main" src="https://user-images.githubusercontent.com/55300322/146618369-37126230-6e67-4935-b27b-cf66920455ee.PNG">

Both end up being named `master` because that's Semaphore's expectation.

Closes #145 