### PR TITLE
fixed mistake in the casc file for jenkins configuration

### DIFF
--- a/control-services/images/jenkins/casc_template.yaml
+++ b/control-services/images/jenkins/casc_template.yaml
@@ -2,8 +2,8 @@ jenkins:
   authorizationStrategy:
     globalMatrix:
       permissions:
-      - "Overall/Administer:${JENKINS_ADMIN_ID}"
-      - "Overall/Read:authenticated"
+      - Overall/Administer:${JENKINS_ADMIN_ID}
+      - Overall/Read:authenticated
   remotingSecurity:
     enabled: 'true'
   securityRealm:

--- a/control-services/images/jenkins/casc_template.yaml
+++ b/control-services/images/jenkins/casc_template.yaml
@@ -12,6 +12,11 @@ jenkins:
       users:
       - id: ${JENKINS_ADMIN_ID}
         password: ${JENKINS_ADMIN_PASSWORD}
+security:
+  queueItemAuthenticator:
+    authenticators:
+    - global:
+        strategy: triggeringUsersAuthorizationStrategy
 unclassified:
   location:
     url: ''

--- a/control-services/images/jenkins/casc_template.yaml
+++ b/control-services/images/jenkins/casc_template.yaml
@@ -2,8 +2,8 @@ jenkins:
   authorizationStrategy:
     globalMatrix:
       permissions:
-      - Overall/Administer:${JENKINS_ADMIN_ID}
-      - Overall/Read:authenticated
+      - USER:Overall/Administer:${JENKINS_ADMIN_ID}
+      - GROUP:Overall/Read:authenticated
   remotingSecurity:
     enabled: 'true'
   securityRealm:

--- a/control-services/images/jenkins/casc_template.yaml
+++ b/control-services/images/jenkins/casc_template.yaml
@@ -2,8 +2,8 @@ jenkins:
   authorizationStrategy:
     globalMatrix:
       permissions:
-      - Overall/Administer:admin
-      - Overall/Read:authenticated
+      - "Overall/Administer:${JENKINS_ADMIN_ID}"
+      - "Overall/Read:authenticated"
   remotingSecurity:
     enabled: 'true'
   securityRealm:


### PR DESCRIPTION
Jenkins casc template originally specified the admin user as literally being called "admin" - should be the "ADMIN_USER_ID" env variable

fixes https://github.com/uwardlaw/vater/issues/163